### PR TITLE
Bumped rand dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ glyph_brush = "0.2.2"
 
 [dev-dependencies]
 rand = "0.6"
+rand_core = "0.2.2" # workaround, see https://github.com/rust-random/rand/issues/645

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ fnv = "1.0.6"
 glyph_brush = "0.2.2"
 
 [dev-dependencies]
-rand = "0.5"
+rand = "0.6"


### PR DESCRIPTION
Seemed like none of the new features are used (the only place this dependency is used is `examples/tetras.rs`)