### PR TITLE
Added sdl2_bundled and sdl2_static_link features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 keywords = ["game", "engine", "framework", "gamedev"]
 categories = ["game-engines"]
 
+[features]
+sdl2_bundled = ["sdl2/bundled"]
+sdl2_static_link = ["sdl2/static-link"]
+
 [dependencies]
 gl = "0.11.0"
 sdl2 = "0.32.0"


### PR DESCRIPTION
SDL2 has a nice feature called "bundled": https://github.com/Rust-SDL2/rust-sdl2#bundled-feature

```
Since 0.31, this crate supports a feature named "bundled" which downloads SDL2 from source, compiles it and links it automatically. While this should work for any architecture, you will need a C compiler (like gcc, clang, or MS's own compiler) to use this feature properly.
```

In addition, for my games I also link things statically. SDL2 has a feature for that called "static-link": 

```
Static linking with MinGW
If you want to use the static-link feature with the windows-gnu toolchain, then you will also need the following libraries:

libimm32.a
libversion.a
libdinput8.a
libdxguid.a
These files are not currently included with the windows-gnu toolchain, but can be downloaded here. For the x86_64 toolchain, you want the x86_64-win32-seh package, and for i686 you want the i686-win32-dwarf one.

You will find the aforementioned libraries under mingw64/x86_64-w64-mingw32/lib/ (for x86_64) or mingw32/i686-w64-mingw32/lib/ (for i686). Copy them to your toolchain's lib directory (the same one you copied the SDL .a files to).
```

```
Static linking with MSVC
The MSVC development libraries provided by http://libsdl.org/ don't include a static library. This means that if you want to use the static-link feature with the windows-msvc toolchain, you have to either

build an SDL2 static library yourself and copy it to your toolchain's lib directory; or
also enable the bundled feature, which will build a static library for you.
```