### PR TITLE
Converted the project to use edition = "2018"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/tetra"
 readme = "README.md"
 keywords = ["game", "engine", "framework", "gamedev"]
 categories = ["game-engines"]
+edition = "2018"
 
 [features]
 sdl2_bundled = ["sdl2/bundled"]

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -1,7 +1,5 @@
 // using sprites by 0x72: https://0x72.itch.io/16x16-industrial-tileset
 
-extern crate tetra;
-
 use tetra::glm::Vec2;
 use tetra::graphics::{self, Animation, Color, DrawParams, Rectangle, Texture};
 use tetra::{Context, ContextBuilder, State};

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,5 +1,3 @@
-extern crate tetra;
-
 use tetra::graphics::{self, Color};
 use tetra::{Context, ContextBuilder, State};
 

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -1,5 +1,3 @@
-extern crate tetra;
-
 use tetra::glm::Vec2;
 use tetra::graphics::{self, Color, DrawParams, Texture};
 use tetra::input::{self, Key};

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -1,5 +1,3 @@
-extern crate tetra;
-
 use tetra::glm::{self, Vec2};
 use tetra::graphics::{self, Color, DrawParams, Texture};
 use tetra::input::{self, MouseButton};

--- a/examples/nineslice.rs
+++ b/examples/nineslice.rs
@@ -1,5 +1,3 @@
-extern crate tetra;
-
 use tetra::glm::Vec2;
 use tetra::graphics::color;
 use tetra::graphics::{self, NineSlice, Rectangle, Texture};

--- a/examples/tetras.rs
+++ b/examples/tetras.rs
@@ -1,8 +1,5 @@
 // Loosely based on https://github.com/jonhoo/tetris-tutorial
 
-extern crate rand;
-extern crate tetra;
-
 use rand::Rng;
 use tetra::glm::Vec2;
 use tetra::graphics::color;

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,5 +1,3 @@
-extern crate tetra;
-
 use tetra::glm::Vec2;
 use tetra::graphics::{self, Color, Font, Text};
 use tetra::{Context, ContextBuilder, State};

--- a/examples/texture.rs
+++ b/examples/texture.rs
@@ -1,5 +1,3 @@
-extern crate tetra;
-
 use tetra::glm::Vec2;
 use tetra::graphics::{self, Color, Texture};
 use tetra::{Context, ContextBuilder, State};

--- a/src/graphics/animation.rs
+++ b/src/graphics/animation.rs
@@ -1,8 +1,8 @@
 //! Functions and types relating to animations.
 
-use graphics::texture::Texture;
-use graphics::{DrawParams, Drawable, Rectangle};
-use Context;
+use crate::graphics::texture::Texture;
+use crate::graphics::{DrawParams, Drawable, Rectangle};
+use crate::Context;
 
 /// An animaton, cycling between regions of a texture at a regular interval.
 ///

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -20,12 +20,12 @@ pub use self::text::{Font, Text};
 pub use self::texture::Texture;
 pub use self::ui::NineSlice;
 
-use glm::{self, Mat3, Mat4, Vec2, Vec3};
+use crate::glm::{self, Mat3, Mat4, Vec2, Vec3};
 use glyph_brush::{GlyphBrush, GlyphBrushBuilder};
-use graphics::opengl::{
+use crate::graphics::opengl::{
     BufferUsage, GLDevice, GLFramebuffer, GLIndexBuffer, GLVertexBuffer, TextureFormat,
 };
-use Context;
+use crate::Context;
 
 const VERTEX_STRIDE: usize = 8;
 const VERTEX_CAPACITY: usize = 4096;

--- a/src/graphics/opengl.rs
+++ b/src/graphics/opengl.rs
@@ -1,6 +1,6 @@
-use error::{Result, TetraError};
+use crate::error::{Result, TetraError};
 use gl::{self, types::*};
-use glm::Mat4;
+use crate::glm::Mat4;
 use sdl2::{
     video::{GLContext, GLProfile, Window},
     VideoSubsystem,

--- a/src/graphics/shader.rs
+++ b/src/graphics/shader.rs
@@ -4,9 +4,9 @@ use std::fs;
 use std::path::Path;
 use std::rc::Rc;
 
-use error::{Result, TetraError};
-use graphics::opengl::GLProgram;
-use Context;
+use crate::error::{Result, TetraError};
+use crate::graphics::opengl::GLProgram;
+use crate::Context;
 
 /// A shader program, consisting of a vertex shader and a fragment shader.
 ///

--- a/src/graphics/text.rs
+++ b/src/graphics/text.rs
@@ -7,10 +7,10 @@ use std::path::Path;
 use glyph_brush::rusttype::{Rect, Scale};
 use glyph_brush::{BrushAction, BrushError, FontId, GlyphVertex, Section};
 
-use error::{Result, TetraError};
-use graphics::opengl::GLDevice;
-use graphics::{self, ActiveShader, ActiveTexture, DrawParams, Drawable, Texture, TextureFormat};
-use Context;
+use crate::error::{Result, TetraError};
+use crate::graphics::opengl::GLDevice;
+use crate::graphics::{self, ActiveShader, ActiveTexture, DrawParams, Drawable, Texture, TextureFormat};
+use crate::Context;
 
 struct FontQuad {
     x1: f32,

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -3,12 +3,10 @@
 use std::path::Path;
 use std::rc::Rc;
 
-use image;
-
-use error::{Result, TetraError};
-use graphics::opengl::{GLTexture, TextureFormat};
-use graphics::{self, ActiveShader, DrawParams, Drawable, Rectangle};
-use Context;
+use crate::error::{Result, TetraError};
+use crate::graphics::opengl::{GLTexture, TextureFormat};
+use crate::graphics::{self, ActiveShader, DrawParams, Drawable, Rectangle};
+use crate::Context;
 
 /// Texture data.
 ///

--- a/src/graphics/ui.rs
+++ b/src/graphics/ui.rs
@@ -1,7 +1,7 @@
 //! Functions and types relating to user interfaces.
 
-use graphics::{self, ActiveShader, DrawParams, Drawable, Rectangle, Texture};
-use Context;
+use crate::graphics::{self, ActiveShader, DrawParams, Drawable, Rectangle, Texture};
+use crate::Context;
 
 /// A panel made up of nine slices of an image. Useful for panels with borders.
 ///

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,8 +3,7 @@
 use fnv::FnvHashSet;
 use glm::Vec2;
 
-use graphics;
-use Context;
+use crate::{graphics, Context};
 
 /// Represents a key on the player's keyboard.
 pub use sdl2::keyboard::Keycode as Key;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,12 +74,6 @@
 
 #![warn(missing_docs)]
 
-extern crate fnv;
-extern crate gl;
-extern crate glyph_brush;
-extern crate image;
-extern crate sdl2;
-
 pub extern crate nalgebra_glm as glm;
 pub mod error;
 pub mod graphics;
@@ -87,16 +81,15 @@ pub mod input;
 pub mod time;
 
 use std::time::{Duration, Instant};
-
-use glm::Vec2;
+use crate::glm::Vec2;
 use sdl2::event::{Event, WindowEvent};
 use sdl2::video::Window;
 use sdl2::Sdl;
 
-pub use error::{Result, TetraError};
-use graphics::opengl::GLDevice;
-use graphics::GraphicsContext;
-use input::{InputContext, Key};
+pub use crate::error::{Result, TetraError};
+use crate::graphics::opengl::GLDevice;
+use crate::graphics::GraphicsContext;
+use crate::input::{InputContext, Key};
 
 /// A trait representing a type that contains game state and provides logic for updating it
 /// and drawing it to the screen. This is where you'll write your game logic!


### PR DESCRIPTION
Rust stable supports `edition = "2018"` since the 1.31.0 release (2018-12-06): https://github.com/rust-lang/rust/blob/master/RELEASES.md

Depending on which rust compiler we want to support, we can already switch to 2018. This a completely optional change though.