### PR TITLE
Added keystrokes to the input

### DIFF
--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -27,6 +27,10 @@ impl State for GameState {
         if input::is_key_down(ctx, Key::S) {
             self.position.y += 2.0;
         }
+        let mut result = input::get_key_strokes(ctx).peekable();
+        if result.peek().is_some() {
+            println!("Keys pressed this tick: {:?}", result.collect::<Vec<_>>());
+        }
     }
 
     fn draw(&mut self, ctx: &mut Context, _dt: f64) {

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -27,9 +27,9 @@ impl State for GameState {
         if input::is_key_down(ctx, Key::S) {
             self.position.y += 2.0;
         }
-        let mut result = input::get_key_strokes(ctx).peekable();
-        if result.peek().is_some() {
-            println!("Keys pressed this tick: {:?}", result.collect::<Vec<_>>());
+        let mut key_strokes = input::get_key_strokes(ctx).peekable();
+        if key_strokes.peek().is_some() {
+            println!("Keys pressed this tick: {:?}", key_strokes.collect::<Vec<_>>());
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -52,6 +52,15 @@ pub fn is_key_released(ctx: &Context, key: Key) -> bool {
     ctx.input.previous_key_state.contains(&key) && !ctx.input.current_key_state.contains(&key)
 }
 
+/// Returns a list of keys that were pressed this tick. This can be used for text input.
+pub fn get_key_strokes<'a>(ctx: &'a Context) -> impl Iterator<Item = Key> + 'a {
+    ctx.input
+        .current_key_state
+        .iter()
+        .cloned()
+        .filter(move |k| !ctx.input.previous_key_state.contains(&k))
+}
+
 /// Returns true if the specified mouse button is currently down.
 pub fn is_mouse_button_down(ctx: &Context, button: MouseButton) -> bool {
     ctx.input.current_mouse_state.contains(&button)


### PR DESCRIPTION
When trying to make a text input component, I found out there's no way to detect what keys were pressed this tick.

The current implementation is lazy, although we might want to make this allocated since the returned iterator borrows the given `Context`. On the other hand, it's fairly easy to call `.collect::<Vec<_>>()`

I didn't think a `get_key_releases` method would be useful, but I'll add it if you think otherwise.