### PR TITLE
 Added `get_size` to `Text` and renamed the old `size` to `scale`

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -33,5 +33,7 @@ fn main() -> tetra::Result {
         pos: Vec2::new(16.0, 16.0),
     };
 
+    println!("Text size is {:?}", state.text.get_size(ctx));
+
     tetra::run(ctx, state)
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -33,7 +33,8 @@ fn main() -> tetra::Result {
         pos: Vec2::new(16.0, 16.0),
     };
 
-    println!("Text size is {:?}", state.text.get_size(ctx));
+    // Text bounds are Some(Rectangle { x: 0.0, y: 2.0, width: 403.0, height: 46.0 })
+    println!("Text bounds are {:?}", state.text.get_bounds(ctx));
 
     tetra::run(ctx, state)
 }


### PR DESCRIPTION
I wanted to add a method `get_size` to `Text`, and figured that the old `set_size` actually sets the scale, so I made a breaking change and renamed that. That might make this a better PR for the 0.2 branch.

I've also moved the `clear the internal quads` logic to the `invalidate` method.

This could be made faster if we make the assumptions that `new_quads[i].x2 > new_quads[i].x1` but I wasn't sure if that was the case.