### PR TITLE
Added some utility functions to animations and updated example

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -41,7 +41,7 @@ impl State for GameState {
             self.set_animation_2();
         }
         if input::is_key_pressed(ctx, Key::Space) {
-            self.animation.restart_animation();
+            self.animation.restart();
         }
     }
 

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -5,6 +5,7 @@ extern crate tetra;
 use tetra::glm::Vec2;
 use tetra::graphics::{self, Animation, Color, DrawParams, Rectangle, Texture};
 use tetra::{Context, ContextBuilder, State};
+use tetra::input::{self, Key};
 
 struct GameState {
     animation: Animation,
@@ -20,11 +21,28 @@ impl GameState {
             ),
         })
     }
+
+    pub fn set_animation_1(&mut self,) {
+        self.animation.set_frames(Rectangle::row(0.0, 272.0, 16.0, 16.0).take(8).collect());
+    }
+
+    pub fn set_animation_2(&mut self,) {
+        self.animation.set_frames(Rectangle::row(0.0, 256.0, 16.0, 16.0).take(8).collect());
+    }
 }
 
 impl State for GameState {
-    fn update(&mut self, _ctx: &mut Context) {
+    fn update(&mut self, ctx: &mut Context) {
         self.animation.tick();
+        if input::is_key_pressed(ctx, Key::Num1) {
+            self.set_animation_1();
+        }
+        if input::is_key_pressed(ctx, Key::Num2) {
+            self.set_animation_2();
+        }
+        if input::is_key_pressed(ctx, Key::Space) {
+            self.animation.restart_animation();
+        }
     }
 
     fn draw(&mut self, ctx: &mut Context, _dt: f64) {

--- a/src/graphics/animation.rs
+++ b/src/graphics/animation.rs
@@ -47,13 +47,13 @@ impl Animation {
     }
 
     /// Set the new frame length for this animation. This will make the animation run at the new length right away.
-    /// If you want to reset the animation to 0, call `restart_animation`
+    /// If you want to reset the animation to 0, call `restart`
     pub fn set_frame_length(&mut self, new_frame_length: i32) {
         self.frame_length = new_frame_length;
     }
 
     /// Will restart the current animation from the beginning.
-    pub fn restart_animation(&mut self) {
+    pub fn restart(&mut self) {
         self.current_frame = 0;
         self.timer = 0;
     }

--- a/src/graphics/animation.rs
+++ b/src/graphics/animation.rs
@@ -38,6 +38,25 @@ impl Animation {
             self.timer = 0;
         }
     }
+
+    /// Set new frames for this animation, while keeping the old texture and frame length. This will reset the current animation.
+    pub fn set_frames(&mut self, new_frames: Vec<Rectangle>) {
+        self.frames = new_frames;
+        self.current_frame = 0;
+        self.timer = 0;
+    }
+
+    /// Set the new frame length for this animation. This will make the animation run at the new length right away.
+    /// If you want to reset the animation to 0, call `restart_animation`
+    pub fn set_frame_length(&mut self, new_frame_length: i32) {
+        self.frame_length = new_frame_length;
+    }
+
+    /// Will restart the current animation from the beginning.
+    pub fn restart_animation(&mut self) {
+        self.current_frame = 0;
+        self.timer = 0;
+    }
 }
 
 impl Drawable for Animation {


### PR DESCRIPTION
Noticed that `Animation` didn't have a way to update the animation when it's already configured.

I've also updated the example. It now has the following buttons:
- 1: switch to the first (initial) animation
- 2: switch to a different animation
- Space: reset the animation to frame 0