### PR TITLE
Explicitly bind vertex attributes

### DIFF
--- a/src/graphics/opengl.rs
+++ b/src/graphics/opengl.rs
@@ -214,6 +214,13 @@ impl GLDevice {
 
             let program_id = gl::CreateProgram();
 
+            // TODO: IDK if this should be applied to *all* shaders...
+            let pos_tex_name = CString::new("in_pos_tex").unwrap();
+            let color_name = CString::new("in_color").unwrap();
+
+            gl::BindAttribLocation(program_id, 0, pos_tex_name.as_ptr());
+            gl::BindAttribLocation(program_id, 1, color_name.as_ptr());
+
             let vertex_id = gl::CreateShader(gl::VERTEX_SHADER);
             gl::ShaderSource(vertex_id, 1, &vertex_buffer.as_ptr(), ptr::null());
             gl::CompileShader(vertex_id);


### PR DESCRIPTION
We could get away without this before, because we were using shader level 330 (which lets you specify the indexes in the shader itself), but now that we're using shader level 130, it's required.

This made it into the release because it seems like NVidia graphics drivers (which I'm using) don't have a problem with you using implicit indexes - on AMD drivers, however, it was causing black screens.