### PR TITLE
Make run_with able to consume variables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ impl Context {
     pub fn run_with<S, F>(&mut self, init: F) -> Result
     where
         S: State,
-        F: Fn(&mut Context) -> Result<S>,
+        F: FnOnce(&mut Context) -> Result<S>,
     {
         let state = &mut init(self)?;
         self.run(state)


### PR DESCRIPTION
While trying to write an example, I noticed that `run_with` currently only has immutable access to the surrounding scope - this is needlessly restrictive.