### PR TITLE
Ensure that the GL context has the correct color buffer settings

### DIFF
--- a/src/graphics/opengl.rs
+++ b/src/graphics/opengl.rs
@@ -25,8 +25,15 @@ pub struct GLDevice {
 impl GLDevice {
     pub fn new(video: &VideoSubsystem, window: &Window, vsync: bool) -> Result<GLDevice> {
         let gl_attr = video.gl_attr();
+
         gl_attr.set_context_profile(GLProfile::Core);
         gl_attr.set_context_version(3, 2);
+        gl_attr.set_red_size(8);
+        gl_attr.set_green_size(8);
+        gl_attr.set_blue_size(8);
+        gl_attr.set_alpha_size(8);
+        gl_attr.set_double_buffer(true);
+        // TODO: Will need to add some more here if we start using the depth/stencil buffers
 
         let _ctx = window.gl_create_context().map_err(TetraError::OpenGl)?;
         gl::load_with(|name| video.gl_get_proc_address(name) as *const _);


### PR DESCRIPTION
Every other implementation of a SDL/OpenGL renderer I've seen does this (e.g. FNA, Love2D, etc), so seems like we should probably be doing it too.