### PR TITLE
Explicitly bind the texture sampler (fixes #67)

### DIFF
--- a/src/graphics/opengl.rs
+++ b/src/graphics/opengl.rs
@@ -259,7 +259,11 @@ impl GLDevice {
             gl::DeleteShader(vertex_id);
             gl::DeleteShader(fragment_id);
 
-            Ok(GLProgram { id: program_id })
+            let program = GLProgram { id: program_id };
+
+            self.set_uniform(&program, "sampler1", 0);
+
+            Ok(program)
         }
     }
 
@@ -389,7 +393,7 @@ impl GLDevice {
             )
         }
     }
-    
+
     pub fn new_framebuffer(&mut self) -> GLFramebuffer {
         unsafe {
             let mut id = 0;


### PR DESCRIPTION
Improves compatibility at basically no cost, so let's do it.