### PR TITLE
Added a fix where an nvidia driver on linux would fail to create a context after the profile is set

### DIFF
--- a/src/graphics/opengl.rs
+++ b/src/graphics/opengl.rs
@@ -26,6 +26,8 @@ impl GLDevice {
     pub fn new(video: &VideoSubsystem, window: &Window, vsync: bool) -> Result<GLDevice> {
         let gl_attr = video.gl_attr();
 
+        let _ctx = window.gl_create_context().map_err(TetraError::OpenGl)?;
+
         gl_attr.set_context_profile(GLProfile::Core);
         gl_attr.set_context_version(3, 2);
         gl_attr.set_red_size(8);
@@ -35,7 +37,6 @@ impl GLDevice {
         gl_attr.set_double_buffer(true);
         // TODO: Will need to add some more here if we start using the depth/stencil buffers
 
-        let _ctx = window.gl_create_context().map_err(TetraError::OpenGl)?;
         gl::load_with(|name| video.gl_get_proc_address(name) as *const _);
 
         video


### PR DESCRIPTION
So this is an issue very specific to the nvidia driver for linux...

More info can be found here: https://stackoverflow.com/questions/42013957/error-creating-opengl-context-with-sdl-badmatch

Nvidia gives an error `Error creating opengl context (BadMatch)` if a gl context is created after either `gl_attr.set_context_profile(GLProfile::Core);` or `gl_attr.set_context_version(3, 2);` is called.

Moving the `let _ctx = window.gl_create_context().map_err(TetraError::OpenGl)?;` line above the gl_attr seemed to have fixed the issue. However, I don't know if this has any side effects.

Alternatively we could change the order of the instructions if we detect we're on linux + nvidia, but that sounds more of a pain.