### PR TITLE
Fix GL context initialization on Linux NVidia drivers

### DIFF
--- a/src/graphics/opengl.rs
+++ b/src/graphics/opengl.rs
@@ -4,10 +4,8 @@ use std::ptr;
 
 use gl::{self, types::*};
 use glm::Mat4;
-use sdl2::{
-    video::{GLContext, GLProfile, Window},
-    VideoSubsystem,
-};
+use sdl2::video::{GLContext, Window};
+use sdl2::VideoSubsystem;
 
 use crate::error::{Result, TetraError};
 
@@ -24,17 +22,6 @@ pub struct GLDevice {
 
 impl GLDevice {
     pub fn new(video: &VideoSubsystem, window: &Window, vsync: bool) -> Result<GLDevice> {
-        let gl_attr = video.gl_attr();
-
-        gl_attr.set_context_profile(GLProfile::Core);
-        gl_attr.set_context_version(3, 2);
-        gl_attr.set_red_size(8);
-        gl_attr.set_green_size(8);
-        gl_attr.set_blue_size(8);
-        gl_attr.set_alpha_size(8);
-        gl_attr.set_double_buffer(true);
-        // TODO: Will need to add some more here if we start using the depth/stencil buffers
-
         let _ctx = window.gl_create_context().map_err(TetraError::OpenGl)?;
         gl::load_with(|name| video.gl_get_proc_address(name) as *const _);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub mod window;
 use std::time::{Duration, Instant};
 
 use sdl2::event::{Event, WindowEvent};
-use sdl2::video::{FullscreenType, Window};
+use sdl2::video::{FullscreenType, GLProfile, Window};
 use sdl2::Sdl;
 
 pub use crate::error::{Result, TetraError};
@@ -422,6 +422,16 @@ impl<'a> ContextBuilder<'a> {
     pub fn build(&self) -> Result<Context> {
         let sdl = sdl2::init().map_err(TetraError::Sdl)?;
         let video = sdl.video().map_err(TetraError::Sdl)?;
+
+        let gl_attr = video.gl_attr();
+        gl_attr.set_context_profile(GLProfile::Core);
+        gl_attr.set_context_version(3, 2);
+        gl_attr.set_red_size(8);
+        gl_attr.set_green_size(8);
+        gl_attr.set_blue_size(8);
+        gl_attr.set_alpha_size(8);
+        gl_attr.set_double_buffer(true);
+        // TODO: Will need to add some more here if we start using the depth/stencil buffers
 
         let (mut window_width, mut window_height) = if let Some(size) = self.window_size {
             size


### PR DESCRIPTION
Alternative approach to #71 which should hopefully fix the issue but allow us to keep explicitly setting our context settings. Figured out thanks to the smart people over at https://github.com/gfx-rs/gfx/pull/1603.

@VictorKoenders: Please try pulling this branch and let me know if it solves your issue - if so I'll merge and do a 0.2.4 release :)