### PR TITLE
Switch to hashbrown for maps/sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ gl = "0.11.0"
 sdl2 = "0.32.1"
 image = "0.21.0"
 glm = { version = "0.2.0", package = "nalgebra-glm" }
-fnv = "1.0.6"
+hashbrown = "0.1.8"
 glyph_brush = "0.2.4"
 rodio = "0.8.1"
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -61,12 +61,12 @@ opt-level = 1
 
 The impact of this can be observed by running the `bunnymark` example both with and without the `--release` flag. This example adds 100 new sprites to the screen every time the user clicks, until rendering conistently drops below 60fps.
 
-These were the results when I ran it against Tetra 0.2.6 on my local machine:
+These were the results when I ran it against Tetra 0.2.7 on my local machine:
 
 | Configuration | Bunnies Rendered |
 | --- | --- |
-| Debug | 3000 |
-| Release | 128500 |
+| Debug | 2900 |
+| Release | 127500 |
 
 For reference, my system specs are:
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,7 +8,7 @@
 //! If a controller is disconnected, the next controller to be connected will take its index - otherwise,
 //! a new one will be allocated. This behaviour might be made smarter in future versions.
 
-use fnv::{FnvHashMap, FnvHashSet};
+use hashbrown::{HashMap, HashSet};
 use glm::Vec2;
 use sdl2::controller::{Axis as SdlAxis, Button as SdlButton, GameController};
 use sdl2::event::Event;
@@ -111,34 +111,34 @@ pub enum GamepadStick {
 
 struct GamepadState {
     sdl_controller: GameController,
-    current_button_state: FnvHashSet<GamepadButton>,
-    previous_button_state: FnvHashSet<GamepadButton>,
-    current_axis_state: FnvHashMap<GamepadAxis, f32>,
+    current_button_state: HashSet<GamepadButton>,
+    previous_button_state: HashSet<GamepadButton>,
+    current_axis_state: HashMap<GamepadAxis, f32>,
 }
 
 impl GamepadState {
     pub(crate) fn new(sdl_controller: GameController) -> GamepadState {
         GamepadState {
             sdl_controller,
-            current_button_state: FnvHashSet::default(),
-            previous_button_state: FnvHashSet::default(),
-            current_axis_state: FnvHashMap::default(),
+            current_button_state: HashSet::new(),
+            previous_button_state: HashSet::new(),
+            current_axis_state: HashMap::new(),
         }
     }
 }
 
 pub(crate) struct InputContext {
-    current_key_state: FnvHashSet<Key>,
-    previous_key_state: FnvHashSet<Key>,
+    current_key_state: HashSet<Key>,
+    previous_key_state: HashSet<Key>,
     current_text_input: Option<String>,
 
-    current_mouse_state: FnvHashSet<MouseButton>,
-    previous_mouse_state: FnvHashSet<MouseButton>,
+    current_mouse_state: HashSet<MouseButton>,
+    previous_mouse_state: HashSet<MouseButton>,
     mouse_position: Vec2,
 
     controller_sys: GameControllerSubsystem,
     pads: Vec<Option<GamepadState>>,
-    sdl_pad_indexes: FnvHashMap<i32, usize>,
+    sdl_pad_indexes: HashMap<i32, usize>,
 }
 
 impl InputContext {
@@ -147,17 +147,17 @@ impl InputContext {
         sdl2::hint::set("SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1");
 
         Ok(InputContext {
-            current_key_state: FnvHashSet::default(),
-            previous_key_state: FnvHashSet::default(),
+            current_key_state: HashSet::new(),
+            previous_key_state: HashSet::new(),
             current_text_input: None,
 
-            current_mouse_state: FnvHashSet::default(),
-            previous_mouse_state: FnvHashSet::default(),
+            current_mouse_state: HashSet::new(),
+            previous_mouse_state: HashSet::new(),
             mouse_position: Vec2::zeros(),
 
             controller_sys,
             pads: Vec::new(),
-            sdl_pad_indexes: FnvHashMap::default(),
+            sdl_pad_indexes: HashMap::new(),
         })
     }
 }


### PR DESCRIPTION
This didn't seem to give us a performance boost, unfortunately, but it didn't observably degrade performance either, based on the bunnymark example. Since we already have several dependencies using hashbrown, I'm going to switch to keep the dependency tree light.

I did notice while implementing this that the benchmarks for 0.2.6 were a little bit dishonest - I recorded them before adding the audio engine, and that seems to have had a small impact on performance. In the interests of transparency, I've updated the figures.