### PR TITLE
Public function to get FPS. (fixes #95)

### DIFF
--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -1,7 +1,5 @@
 /// Based on https://github.com/openfl/openfl-samples/tree/master/demos/BunnyMark
 /// Original BunnyMark (and sprite) by Iain Lobb
-use std::collections::VecDeque;
-use std::time::Instant;
 
 use rand::rngs::ThreadRng;
 use rand::{self, Rng};
@@ -41,8 +39,6 @@ struct GameState {
     max_y: f32,
 
     click_timer: i32,
-    fps_tracker: VecDeque<f64>,
-    last_frame: Instant,
 }
 
 impl GameState {
@@ -65,8 +61,6 @@ impl GameState {
             max_y,
 
             click_timer: 0,
-            fps_tracker: VecDeque::new(),
-            last_frame: Instant::now(),
         })
     }
 }
@@ -119,26 +113,14 @@ impl State for GameState {
             graphics::draw(ctx, &self.texture, bunny.position);
         }
 
-        let current_frame = Instant::now();
-        let elapsed = current_frame - self.last_frame;
-
-        self.fps_tracker.push_back(time::duration_to_f64(elapsed));
-
-        if self.fps_tracker.len() > 200 {
-            self.fps_tracker.pop_front();
-        }
-
-        let fps = 1.0 / (self.fps_tracker.iter().sum::<f64>() / self.fps_tracker.len() as f64);
         window::set_title(
             ctx,
             &format!(
                 "BunnyMark - {} bunnies - {:.0} FPS",
                 self.bunnies.len(),
-                fps
+                time::get_fps(ctx)
             ),
         );
-
-        self.last_frame = current_frame;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub mod time;
 pub mod window;
 
 use std::time::{Duration, Instant};
+use std::collections::VecDeque;
 
 use sdl2::event::{Event, WindowEvent};
 use sdl2::video::{FullscreenType, GLProfile, Window};
@@ -130,6 +131,7 @@ pub struct Context {
     running: bool,
     quit_on_escape: bool,
     tick_rate: Duration,
+    fps_tracker: VecDeque<f64>
 }
 
 impl Context {
@@ -171,6 +173,9 @@ impl Context {
             let elapsed = current_time - last_time;
             last_time = current_time;
             lag += elapsed;
+
+            if self.fps_tracker.len() == self.fps_tracker.capacity() { self.fps_tracker.pop_front(); }
+            self.fps_tracker.push_back(time::duration_to_f64(elapsed));
 
             for event in events.poll_iter() {
                 if let Err(e) = self
@@ -519,6 +524,7 @@ impl<'a> ContextBuilder<'a> {
             running: false,
             quit_on_escape: self.quit_on_escape,
             tick_rate: time::f64_to_duration(self.tick_rate),
+            fps_tracker: VecDeque::<f64>::with_capacity(250)
         })
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -29,3 +29,8 @@ pub fn get_tick_rate(ctx: &Context) -> f64 {
 pub fn set_tick_rate(ctx: &mut Context, tick_rate: f64) {
     ctx.tick_rate = f64_to_duration(1.0 / tick_rate);
 }
+
+/// Calculates FPS from average frame durations
+pub fn get_fps(ctx: &Context) -> f64 {
+    1.0 / (ctx.fps_tracker.iter().sum::<f64>() / ctx.fps_tracker.len() as f64)
+}


### PR DESCRIPTION
Added FPS tracker in the BunnyMark example to the Context, also updated example to use the new FPS function.