### PR TITLE
Fixes for the tutorial part 01

### DIFF
--- a/docs/tutorial/01-creating-a-project.md
+++ b/docs/tutorial/01-creating-a-project.md
@@ -52,7 +52,7 @@ If you run `cargo run` in your terminal now, you'll notice that the window pops 
 For now, we don't need to store data or override any of the default behaviour, so we can just use an empty struct and implementation:
 
 ```rust ,noplaypen
-# use tetra::{ContextBuilder, State};
+use tetra::{ContextBuilder, State};
 #
 struct GameState {}
 

--- a/docs/tutorial/01-creating-a-project.md
+++ b/docs/tutorial/01-creating-a-project.md
@@ -7,11 +7,11 @@ cargo new --bin pong
 cd pong
 ```
 
-To add Tetra as a dependency, make sure you have the following lines 
-in the your `Cargo.toml`:
+To add Tetra as a dependency, make sure you add the following line
+in your `Cargo.toml`:
 
 ```toml
-[dependencies]
+# [dependencies]
 tetra = "0.3"
 ```
 
@@ -28,8 +28,8 @@ This is a struct that stores all of the 'global' state managed by the framework,
 To build a `Context`, we can use the descriptively named `ContextBuilder` struct:
 
 ```rust ,noplaypen
-# use tetra::ContextBuilder;
-#
+use tetra::ContextBuilder;
+
 fn main() {
     ContextBuilder::new("Pong", 640, 480)
         .quit_on_escape(true)

--- a/docs/tutorial/01-creating-a-project.md
+++ b/docs/tutorial/01-creating-a-project.md
@@ -103,8 +103,8 @@ Our goal for this chapter was to set up our project, and we've done that! A blac
 To do this, we'll use one of the `State` trait methods. `draw` is called by Tetra whenever it is time for the engine to draw a new frame. We can call `tetra::graphics::clear` inside this method to clear the window to a plain color:
 
 ```rust ,noplaypen
-# use tetra::graphics::{self, Color};
-# use tetra::{Context, ContextBuilder, State};
+use tetra::graphics::{self, Color};
+use tetra::{Context, ContextBuilder, State};
 # 
 # struct GameState {}
 # 


### PR DESCRIPTION
Minor fixes.

Great start on this tutorial, I really like all of the "side-notes" and also the clarification on the use of Context.

Based on the assumption that you are leveraging the # character to "hide" lines that aren't changed in the current step of the tutorial, I've found some inconsistent use of it... well at least "copying" the code from the code-snippets doesn't compile.

I might be missing something though...

