### PR TITLE
Added mouse wheel support

### DIFF
--- a/examples/camera.rs
+++ b/examples/camera.rs
@@ -51,7 +51,15 @@ impl State for GameState {
             self.camera.zoom += ZOOM_SPEED;
         }
 
+        if input::is_mouse_scroll_up(ctx) {
+            self.camera.zoom += ZOOM_SPEED;
+        }
+
         if input::is_key_down(ctx, Key::F) {
+            self.camera.zoom -= ZOOM_SPEED;
+        }
+
+        if input::is_mouse_scroll_down(ctx) {
             self.camera.zoom -= ZOOM_SPEED;
         }
 

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -4,8 +4,6 @@ use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
 
-use image;
-
 use crate::error::{Result, TetraError};
 use crate::fs;
 use crate::graphics::{self, DrawParams, Drawable, Rectangle};

--- a/src/input.rs
+++ b/src/input.rs
@@ -31,6 +31,7 @@ pub(crate) struct InputContext {
     mouse_buttons_pressed: HashSet<MouseButton>,
     mouse_buttons_released: HashSet<MouseButton>,
     mouse_position: Vec2<f32>,
+    mouse_wheel_delta: Vec2<i32>,
 
     current_text_input: Option<String>,
 
@@ -48,6 +49,7 @@ impl InputContext {
             mouse_buttons_pressed: HashSet::new(),
             mouse_buttons_released: HashSet::new(),
             mouse_position: Vec2::zero(),
+            mouse_wheel_delta: Vec2::zero(),
 
             current_text_input: None,
 
@@ -61,6 +63,7 @@ pub(crate) fn clear(ctx: &mut Context) {
     ctx.input.keys_released.clear();
     ctx.input.mouse_buttons_pressed.clear();
     ctx.input.mouse_buttons_released.clear();
+    ctx.input.mouse_wheel_delta = Vec2::zero();
 
     ctx.input.current_text_input = None;
 
@@ -75,7 +78,7 @@ pub(crate) fn clear(ctx: &mut Context) {
 /// Returns the text that the user entered since the last update.
 /// This will match the user's keyboard and OS settings.
 pub fn get_text_input(ctx: &Context) -> Option<&str> {
-    ctx.input.current_text_input.as_ref().map(String::as_str)
+    ctx.input.current_text_input.as_deref()
 }
 
 pub(crate) fn push_text_input(ctx: &mut Context, text: &str) {

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -48,7 +48,27 @@ pub fn get_mouse_y(ctx: &Context) -> f32 {
 
 /// Get the position of the mouse.
 pub fn get_mouse_position(ctx: &Context) -> Vec2<f32> {
-    Vec2::new(get_mouse_x(ctx), get_mouse_y(ctx))
+    ctx.input.mouse_position
+}
+
+/// Get the change in mouse wheel value of the mouse since the last update.
+pub fn get_mouse_wheel_delta_y(ctx: &Context) -> i32 {
+    ctx.input.mouse_wheel_delta.y
+}
+
+/// Get the change in mouse wheel value of the mouse since the last update.
+pub fn get_mouse_wheel_delta_x(ctx: &Context) -> i32 {
+    ctx.input.mouse_wheel_delta.x
+}
+
+/// Check if the user scrolled up in this frame.
+pub fn is_mouse_scroll_up(ctx: &Context) -> bool {
+    get_mouse_wheel_delta_y(ctx) < 0
+}
+
+/// Check if the user scrolled up in this frame.
+pub fn is_mouse_scroll_down(ctx: &Context) -> bool {
+    get_mouse_wheel_delta_y(ctx) > 0
 }
 
 pub(crate) fn set_mouse_button_down(ctx: &mut Context, btn: MouseButton) -> bool {
@@ -73,4 +93,8 @@ pub(crate) fn set_mouse_button_up(ctx: &mut Context, btn: MouseButton) -> bool {
 
 pub(crate) fn set_mouse_position(ctx: &mut Context, position: Vec2<f32>) {
     ctx.input.mouse_position = position;
+}
+
+pub(crate) fn set_mouse_wheel_delta(ctx: &mut Context, wheel_delta: Vec2<i32>) {
+    ctx.input.mouse_wheel_delta = wheel_delta;
 }

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -77,6 +77,12 @@ pub enum Event {
         position: Vec2<f32>,
     },
 
+    /// The mouse wheel value was changed.
+    MouseWheelDelta {
+        /// The difference in the wheel position. Usually you want to check for the `y` value, as this is a "normal" scroll action.
+        delta: Vec2<i32>,
+    },
+
     /// A gamepad was connected to the system.
     GamepadAdded {
         /// The ID that was assigned to the gamepad.

--- a/src/platform/window_sdl.rs
+++ b/src/platform/window_sdl.rs
@@ -6,7 +6,7 @@ use sdl2::controller::{Axis as SdlGamepadAxis, Button as SdlGamepadButton, GameC
 use sdl2::event::{Event as SdlEvent, WindowEvent};
 use sdl2::haptic::Haptic;
 use sdl2::keyboard::Keycode as SdlKey;
-use sdl2::mouse::MouseButton as SdlMouseButton;
+use sdl2::mouse::{MouseButton as SdlMouseButton, MouseWheelDirection};
 use sdl2::sys::SDL_HAPTIC_INFINITY;
 use sdl2::video::{
     FullscreenType, GLContext as SdlGlContext, GLProfile, SwapInterval, Window as SdlWindow,
@@ -353,6 +353,19 @@ where
                 let position = Vec2::new(x as f32, y as f32);
                 input::set_mouse_position(ctx, position);
                 state.event(ctx, Event::MouseMoved { position })?;
+            }
+
+            SdlEvent::MouseWheel {
+                x, y, direction, ..
+            } => {
+                let is_flipped = direction == MouseWheelDirection::Flipped;
+                let delta = if is_flipped {
+                    Vec2::new(x, y)
+                } else {
+                    Vec2::new(-x, -y)
+                };
+                input::set_mouse_wheel_delta(ctx, delta);
+                state.event(ctx, Event::MouseWheelDelta { delta })?
             }
 
             SdlEvent::TextInput { text, .. } => {


### PR DESCRIPTION
Added mouse wheel support. I tried making this generic, as touchpads (and some mice) can also scroll horizontally, and potentially in other directions.

Therefor I've labelled it `mouse_wheel_delta` as much as possible, but I did add some helper functions for up/down scroll, as this is probably the most used functionality of this feature.

The direction flip should be in line with the [documentation](https://wiki.libsdl.org/SDL_MouseWheelEvent):

> Movements to the left generate negative x values and to the right generate positive x values. Movements down (scroll backward) generate negative y values and up (scroll forward) generate positive y values. 
> ...
> SDL does not abstract the mouse wheel scroll directions to be consistent across all platforms (SDL_MOUSEWHEEL_NORMAL). If direction is SDL_MOUSEWHEEL_FLIPPED the values in x and y will be opposite. Multiply by -1 to change them back. 
> 

In addition, my editor complained about the `.as_ref().map(String::as_str)` line. In [Rust 1.40 (Dec 19, 2019)](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html) the method `Option::as_deref` was stabilized. Let me know if you want me to revert this so tetra can support older compilers (I did not find a minimal supported rust version)