### PR TITLE
Added methods to allow for fine-tuned animation control

### DIFF
--- a/src/graphics/animation.rs
+++ b/src/graphics/animation.rs
@@ -92,6 +92,34 @@ impl Animation {
     pub fn set_frame_length(&mut self, new_frame_length: Duration) {
         self.frame_length = new_frame_length;
     }
+
+    /// Get the current frame that is active. This can be used in combination with [frames](#method.frames) to track the progress of this animation.
+    pub fn current_frame_index(&self) -> usize {
+        self.current_frame
+    }
+
+    /// Set the current frame that is active.  This can be used for fine-tuned animation manipulation.
+    ///
+    /// The given value should be a valid index in the [frames](#method.frames) list, otherwise this animation will panic.
+    pub fn set_current_frame_index(&mut self, new_frame_index: usize) {
+        // Without this check, the code would panic in `Drawable::draw` because `self.frames[self.current_frame]` is invalid,
+        // but the developer would have no clue where it was set.
+        debug_assert!(self.frames.get(new_frame_index).is_some());
+
+        self.current_frame = new_frame_index;
+    }
+
+    /// Get the duration that this frame has been visible. This can be used in combination with [frame_length](#method.frame_length) to track the progress of this animation.
+    pub fn current_frame_time(&self) -> Duration {
+        self.timer
+    }
+
+    /// Set the duration that the current frame has been visible. This can be used for fine-tuned animation manipulation.
+    ///
+    /// The animation will not update until the next call to [advance](#method.advance) or [advance_by](#method.advance_by). If a value is given that is larger than [frame_length](#method.frame_length), this animation may skip frames.
+    pub fn set_current_frame_time(&mut self, new_frame_time: Duration) {
+        self.timer = new_frame_time;
+    }
 }
 
 impl Drawable for Animation {


### PR DESCRIPTION
I decided to implement two methods, one for `(set_)current_frame_index` and one for `(set_)current_frame_time`, because I'd imagine that a developer wants to be able to manipulate both.

Closes #168 
