### PR TITLE
Examples: fix the font path and the repeat keys in the audio one

### DIFF
--- a/examples/audio.rs
+++ b/examples/audio.rs
@@ -36,7 +36,7 @@ impl GameState {
         Ok(GameState {
             text: Text::new(
                 INSTRUCTIONS,
-                Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+                Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
                 16.0,
             ),
             sound,
@@ -63,12 +63,12 @@ impl State for GameState {
                 Key::A => self.channel2.play(),
                 Key::S => self.channel2.pause(),
                 Key::D => self.channel2.stop(),
-                Key::F => self.channel1.toggle_repeating(),
+                Key::F => self.channel2.toggle_repeating(),
 
                 Key::Z => self.channel3.play(),
                 Key::X => self.channel3.pause(),
                 Key::C => self.channel3.stop(),
-                Key::V => self.channel1.toggle_repeating(),
+                Key::V => self.channel3.toggle_repeating(),
 
                 _ => {}
             }

--- a/examples/canvas.rs
+++ b/examples/canvas.rs
@@ -23,7 +23,7 @@ impl GameState {
             shader: Shader::from_fragment_file(ctx, "./examples/resources/disco.frag")?,
             text: Text::new(
                 "",
-                Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+                Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
                 32.0,
             ),
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -10,7 +10,7 @@ impl GameState {
     fn new(ctx: &mut Context) -> tetra::Result<GameState> {
         let text = Text::new(
             "Look at your console to see what events are being fired!",
-            Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+            Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
             16.0,
         );
 

--- a/examples/file_drop.rs
+++ b/examples/file_drop.rs
@@ -13,7 +13,7 @@ impl GameState {
         Ok(GameState {
             file: Text::new(
                 "Drop a file onto this window to view the contents.",
-                Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+                Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
                 16.0,
             ),
         })

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -112,7 +112,7 @@ impl GameState {
 
             axis_info: Text::new(
                 "",
-                Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+                Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
                 16.0,
             ),
         })

--- a/examples/scaling.rs
+++ b/examples/scaling.rs
@@ -31,7 +31,7 @@ impl GameState {
             ),
             text: Text::new(
                 format!("{}\n{:?}", LABEL, ScalingMode::Fixed),
-                Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+                Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
                 16.0,
             ),
         })

--- a/examples/shaders.rs
+++ b/examples/shaders.rs
@@ -20,7 +20,7 @@ impl GameState {
             shader: Shader::from_fragment_file(ctx, "./examples/resources/disco.frag")?,
             text: Text::new(
                 "",
-                Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+                Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
                 32.0,
             ),
 

--- a/examples/tetras.rs
+++ b/examples/tetras.rs
@@ -57,7 +57,7 @@ impl Assets {
             line_clear_fx: Sound::new("./examples/resources/lineclear.wav")?,
             game_over_fx: Sound::new("./examples/resources/gameover.wav")?,
 
-            font: Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+            font: Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
 
             backdrop: Texture::new(ctx, "./examples/resources/backdrop.png")?,
             block: Texture::new(ctx, "./examples/resources/block.png")?,

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -11,7 +11,7 @@ impl GameState {
     fn new(ctx: &mut Context) -> tetra::Result<GameState> {
         let text = Text::new(
             "Hello, world!\n\nThis is some text being rendered from a TTF font.",
-            Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+            Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
             16.0,
         );
 

--- a/examples/text_input.rs
+++ b/examples/text_input.rs
@@ -12,7 +12,7 @@ impl GameState {
         Ok(GameState {
             text: Text::new(
                 "",
-                Font::new(ctx, "./examples/resources/DejaVuSansMono.ttf")?,
+                Font::new(ctx, "./src/resources/DejaVuSansMono.ttf")?,
                 32.0,
             ),
         })


### PR DESCRIPTION
It looks like the font file used in the examples was moved from the examples `resources` directory to the one under `src`, this change fixes the font path in the examples that use it.

It also fixes the repeat key for two of three sounds in the `audio` example. Cheers.