### PR TITLE
Fixed a broken link in the documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! You can see this example in action by running `cargo run --example hello_world`.
 //!
-//! The full list of examples is available [here](https://github.com/17cupsofcoffee/tetra/tree/release/examples).
+//! The full list of examples is available [here](https://github.com/17cupsofcoffee/tetra/tree/master/examples).
 //!
 //! ## Support/Feedback
 //!


### PR DESCRIPTION
The link to the examples from the doc was pointing to an unknown branch. I've pointed it to the master branch.

Optimally we'd point this to the tag of the current version, but I'm not sure if that's possible.

Alternatively you can make a symlink on e.g. `https://tetra.seventeencups.net/doc_examples` that redirects to the latest version's examples.