### PR TITLE
add feature "serde_support" to ContextBuilder

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -146,6 +146,10 @@ impl Context {
 
 /// Settings that can be configured when starting up a game.
 #[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "serde_support",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct ContextBuilder {
     pub(crate) title: String,
     pub(crate) window_width: i32,


### PR DESCRIPTION
The tetra_config can be loaded with [ron](https://github.com/ron-rs/ron) from the filesystem, after adding "serde_support" feature annotation.

![image](https://user-images.githubusercontent.com/10463138/87836239-b45b9200-c88f-11ea-9b1e-d99c2744d758.png)

This is my first public pull request, I hope I did everything right.