### PR TITLE
Fixed it so that the drawing when hidpi is correct (OSX)

### DIFF
--- a/src/platform/window_sdl.rs
+++ b/src/platform/window_sdl.rs
@@ -384,8 +384,8 @@ where
                     // Resizing the window causes the drawing to go wrong until the window is moved.
                     // This is a temporary workaround. (Ref: http://github.com/Rust-SDL2/rust-sdl2/issues/978)
                     if cfg!(target_os = "macos") {
-                        let pos = ctx.window.get_window_pos();
-                        ctx.window.set_window_pos(pos.0, pos.1);
+                        let (x, y) = ctx.window.get_window_pos();
+                        ctx.window.set_window_pos(x, y);
                     }
                 }
 


### PR DESCRIPTION
With this PR, rendering in HiDPI mode on MacOS is rendered correctly in high definition and pixels blur-free.

I briefly tested this fix in Windows as well, and there seemed to be no problem.