### PR TITLE
Add the feature to manually control redraw

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ sdl2_bundled = ["sdl2/bundled"]
 sdl2_static_link = ["sdl2/static-link"]
 
 # Disables automatic drawing for each frame.
-# Even if this feature is enabled, the drawing command will still be processed.
+# Even if this feature is enabled, drawing commands will still be processed.
 # but you will need to call `tetra::graphics::present` to get the actual drawing on the screen.
 # You can reduce the load of the Window Manager on your operating system by manually controlling when drawing needs to be done.
 disable_auto_redraw = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,7 @@ sdl2_bundled = ["sdl2/bundled"]
 
 # Links SDL2 statically (see https://hg.libsdl.org/SDL/file/default/docs/README-dynapi.md).
 sdl2_static_link = ["sdl2/static-link"]
+
+# Disables automatic drawing for each frame.
+# If you enable this feature, you will need to call `tetra::graphics::present` manually.
+disable_auto_redraw = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,7 @@ sdl2_bundled = ["sdl2/bundled"]
 sdl2_static_link = ["sdl2/static-link"]
 
 # Disables automatic drawing for each frame.
-# When this feature is enabled, draw commands will be processed, but you will need to call `tetra::graphics::present` to get the actual drawing on the screen.
+# Even if this feature is enabled, the drawing command will still be processed.
+# but you will need to call `tetra::graphics::present` to get the actual drawing on the screen.
+# You can reduce the load of the Window Manager on your operating system by manually controlling when drawing needs to be done.
 disable_auto_redraw = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,5 @@ sdl2_bundled = ["sdl2/bundled"]
 sdl2_static_link = ["sdl2/static-link"]
 
 # Disables automatic drawing for each frame.
-# If you enable this feature, you will need to call `tetra::graphics::present` manually.
+# When this feature is enabled, draw commands will be processed, but you will need to call `tetra::graphics::present` to get the actual drawing on the screen.
 disable_auto_redraw = []

--- a/src/context.rs
+++ b/src/context.rs
@@ -170,6 +170,7 @@ impl Context {
 
             state.draw(self)?;
 
+            #[cfg(not(feature = "disable_auto_redraw"))]
             graphics::present(self);
 
             // This provides a sensible FPS limit when running without vsync, and


### PR DESCRIPTION
Using this feature to manually repaint when the need to update arises will reduce the CPU and GPU load on the Desktop Window Manager(Windows) or WindowServer(MacOS).
In situations where machine performance is poor, the load on these window managers can be worrisome.

This is a feature needed for a very minor use case that only I need as I am creating tools that are always running.

This is not a perfect retained mode.
