### PR TITLE
Add events related to the display state of the window

### DIFF
--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -62,6 +62,21 @@ pub enum Event {
         height: i32,
     },
 
+    /// The game window was shown by the user.
+    Shown,
+
+    /// The game window was hidden by the user.
+    Hidden,
+
+    /// The game window was restored to normal size and position by the user.
+    Restored,
+
+    /// The game window was minimized by the user.
+    Minimized,
+
+    /// The game window was maximized by the user.
+    Maximized,
+
     /// The game window was focused by the user.
     FocusGained,
 

--- a/src/platform/window_sdl.rs
+++ b/src/platform/window_sdl.rs
@@ -419,6 +419,26 @@ where
                     state.event(ctx, Event::Resized { width, height })?;
                 }
 
+                WindowEvent::Shown => {
+                    state.event(ctx, Event::Shown)?;
+                }
+
+                WindowEvent::Hidden => {
+                    state.event(ctx, Event::Hidden)?;
+                }
+
+                WindowEvent::Restored => {
+                    state.event(ctx, Event::Restored)?;
+                }
+
+                WindowEvent::Minimized => {
+                    state.event(ctx, Event::Minimized)?;
+                }
+
+                WindowEvent::Maximized => {
+                    state.event(ctx, Event::Maximized)?;
+                }
+
                 WindowEvent::FocusGained => {
                     state.event(ctx, Event::FocusGained)?;
                 }


### PR DESCRIPTION
I am currently working on a tool that displays images from a large number of external files.

I need these events to unload textures from VRAM when the window is minimized.
(This requires that `tetra::graphics::present` is called at least once in the tetra lifecycle after the user has released textures)
