### PR TITLE
Add methods to get device pixel ratio

### DIFF
--- a/src/platform/window_sdl.rs
+++ b/src/platform/window_sdl.rs
@@ -234,10 +234,8 @@ impl Window {
         self.window_visible = visible;
     }
 
-    pub fn get_device_pixel_ratio(&self) -> (f32, f32) {
-        let (dw, dh) = self.sdl_window.drawable_size();
-        let (sw, sh) = self.sdl_window.size();
-        (dw as f32 / sw as f32, dh as f32 / sh as f32)
+    pub fn get_device_pixel_ratio(&self) -> f32 {
+        self.sdl_window.drawable_size().0 as f32 / self.sdl_window.size().0 as f32
     }
 
     pub fn get_monitor_count(&self) -> Result<i32> {

--- a/src/platform/window_sdl.rs
+++ b/src/platform/window_sdl.rs
@@ -234,6 +234,12 @@ impl Window {
         self.window_visible = visible;
     }
 
+    pub fn get_device_pixel_ratio(&self) -> (f32, f32) {
+        let (dw, dh) = self.sdl_window.drawable_size();
+        let (sw, sh) = self.sdl_window.size();
+        (dw as f32 / sw as f32, dh as f32 / sh as f32)
+    }
+
     pub fn get_monitor_count(&self) -> Result<i32> {
         self.video_sys
             .num_video_displays()

--- a/src/window.rs
+++ b/src/window.rs
@@ -58,11 +58,6 @@ pub fn get_size(ctx: &Context) -> (i32, i32) {
     ctx.window.get_window_size()
 }
 
-/// Returns the ratio of the logical resolution to the physical resolution of the current display on which the window is being displayed.
-pub fn get_device_pixel_ratio(ctx: &Context) -> (f32, f32) {
-    ctx.window.get_device_pixel_ratio()
-}
-
 /// Sets the size of the window.
 ///
 /// # Errors
@@ -173,6 +168,11 @@ pub fn set_relative_mouse_mode(ctx: &mut Context, relative_mouse_mode: bool) {
 /// as such, you should not rely on it.
 pub fn is_relative_mouse_mode(ctx: &Context) -> bool {
     ctx.window.is_relative_mouse_mode()
+}
+
+/// Returns the ratio of the logical resolution to the physical resolution of the current display on which the window is being displayed.
+pub fn get_device_pixel_ratio(ctx: &Context) -> f32 {
+    ctx.window.get_device_pixel_ratio()
 }
 
 /// Gets the number of monitors connected to the device.

--- a/src/window.rs
+++ b/src/window.rs
@@ -58,6 +58,11 @@ pub fn get_size(ctx: &Context) -> (i32, i32) {
     ctx.window.get_window_size()
 }
 
+/// Returns the ratio of the logical resolution to the physical resolution of the current display on which the window is being displayed.
+pub fn get_device_pixel_ratio(ctx: &Context) -> (f32, f32) {
+    ctx.window.get_device_pixel_ratio()
+}
+
 /// Sets the size of the window.
 ///
 /// # Errors


### PR DESCRIPTION
This method allows you to get the pixel ratio of the display on which the current window is displayed, which is more convenient than `SDL_GetDisplayDPI`


**References:**

- [c++ - SDL Detect High DPI/Retina Display - Stack Overflow](https://stackoverflow.com/a/58666167)
- [Window.devicePixelRatio - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)
