### PR TITLE
Updated vek dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to Semantic Versioning.
     * This is for consistency with existing methods (e.g. on `Color`).
     * The old names have been deprecated, and will be removed in 0.7.
 * Updated `glow` to 0.9.
+* Updated `vek` dependency from 0.13.1 to 0.15.0
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ sdl2 = "0.34.0"
 rodio = { version = "0.11.0", optional = true, default-features = false }
 glow = "0.9.0"
 image = { version = "0.23.12", default-features = false }
-vek = { version = "0.13.1", default-features = false }
+vek = { version = "0.15.0", default-features = false }
 hashbrown = "0.11.0"
 serde = { version = "1.0.104", optional = true } 
 ab_glyph = { version = "0.2.2", optional = true }


### PR DESCRIPTION
Updated vek dependency from 1.13.1 to 0.15.0

Vek's diff: https://github.com/yoanlcq/vek/compare/7a3bca71a05d7c54ef98dc2d67270f04fb2719ec..837cd9bd08f3927dfdbbb8e2223496e77e6533ef
