### PR TITLE
Updated rodio from 0.11 to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-engines"]
 
 [dependencies]
 sdl2 = "0.34.0"
-rodio = { version = "0.11.0", optional = true, default-features = false }
+rodio = { version = "0.13.1", optional = true, default-features = false }
 glow = "0.9.0"
 image = { version = "0.23.12", default-features = false }
 vek = { version = "0.13.1", default-features = false }

--- a/examples/audio.rs
+++ b/examples/audio.rs
@@ -29,7 +29,7 @@ impl GameState {
     fn new(ctx: &mut Context) -> tetra::Result<GameState> {
         audio::set_master_volume(ctx, 0.4);
 
-        let sound = Sound::new("./examples/resources/powerup.wav")?;
+        let sound = Sound::new("./examples/resources/powerup.ogg")?;
         let channel1 = sound.spawn(ctx)?;
         let channel2 = sound.spawn(ctx)?;
         let channel3 = sound.spawn(ctx)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ use image::ImageError;
 use lyon_tessellation::TessellationError;
 
 #[cfg(feature = "audio")]
-use rodio::decoder::DecoderError;
+use rodio::{decoder::DecoderError, PlayError};
 
 /// A specialized [`Result`](std::result::Result) type for Tetra.
 ///
@@ -53,6 +53,10 @@ pub enum TetraError {
     #[cfg(feature = "audio")]
     InvalidSound(DecoderError),
 
+    /// Returned when a sound cannot be decoded.
+    #[cfg(feature = "audio")]
+    AudioPlayError(PlayError),
+
     /// Returned when not enough data is provided to fill a buffer.
     /// This may happen if you're creating a texture from raw data and you don't provide
     /// enough data.
@@ -88,6 +92,8 @@ impl Display for TetraError {
             TetraError::InvalidFont => write!(f, "Invalid font data"),
             #[cfg(feature = "audio")]
             TetraError::InvalidSound(_) => write!(f, "Invalid sound data"),
+            #[cfg(feature = "audio")]
+            TetraError::AudioPlayError(_) => write!(f, "Could not play audio"),
             TetraError::NotEnoughData { expected, actual } => write!(
                 f,
                 "Not enough data was provided to fill a buffer - expected {}, found {}.",
@@ -113,6 +119,8 @@ impl Error for TetraError {
             TetraError::InvalidFont => None,
             #[cfg(feature = "audio")]
             TetraError::InvalidSound(reason) => Some(reason),
+            #[cfg(feature = "audio")]
+            TetraError::AudioPlayError(reason) => Some(reason),
             TetraError::NotEnoughData { .. } => None,
             TetraError::NoAudioDevice => None,
             TetraError::FailedToChangeDisplayMode(_) => None,


### PR DESCRIPTION
Updated rodio.

A breaking change seems to be that devices and audio streams are now two different things. `OutputStream` now has `try_default()` and `OutputStreamHandle` now has `play_raw`.

The `OutputStream` must be kept in memory even though we're only interacting with the `OutputStreamHandle` as per the [documentation](https://docs.rs/rodio/0.13.1/rodio/struct.OutputStream.html):
```markdown
If this (the OutputStream) is dropped playback will end & attached OutputStreamHandles will no longer work.
```

Changelog: https://github.com/RustAudio/rodio/blob/master/CHANGELOG.md
Commits: https://github.com/RustAudio/rodio/compare/7bf8ba5cb629d419a2bd003f8e8e387b1db1f717..c397a4d8d18402badefddea89b53ed42226adb5e