### PR TITLE
Added dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot is a tool that automatically updates all your dependencies.

Homepage: https://dependabot.com/

Github documentation on what dependabot is and how to add it to your repository: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically

After adding this to the tetra project, expect to get pull requests like this: https://github.com/Trangar/at_protocol/pull/3