### PR TITLE
Add hdr option to CanvasBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ This project adheres to Semantic Versioning.
 
 ## [Upcoming]
 
+### Added
+
 ### Changed
 
+* **Breaking:** This crate now uses Rust 2021, and therefore requires at least Rust 1.56.
+* **Breaking:** Most enums in the API are now marked as `non_exhaustive`, and so must have a wildcard arm when matching on them.
+    * This is to make it so adding a new enum variant is not a breaking change in the future.
 * `KeyModifier`'s behaviour has been reverted to be layout-based rather than position-based.
     * This better matches the expected behaviour for keyboard shortcuts (which is the primary use case for this type), and the behaviour of the underlying platform code.
 

--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -18,6 +18,7 @@ pub struct CanvasBuilder {
     height: i32,
     samples: u8,
     stencil_buffer: bool,
+    hdr: bool,
 }
 
 impl CanvasBuilder {
@@ -32,6 +33,7 @@ impl CanvasBuilder {
             height,
             samples: 0,
             stencil_buffer: false,
+            hdr: false,
         }
     }
 
@@ -60,6 +62,15 @@ impl CanvasBuilder {
         self
     }
 
+    /// Sets whether the canvas should support HDR.
+    ///
+    /// Setting this to `true` allows you to store color values greater than 1.0, at the cost
+    /// of some extra video RAM usage.
+    pub fn hdr(&mut self, enabled: bool) -> &mut CanvasBuilder {
+        self.hdr = enabled;
+        self
+    }
+
     /// Builds the canvas.
     ///
     /// # Errors
@@ -73,6 +84,7 @@ impl CanvasBuilder {
             ctx.graphics.default_filter_mode,
             self.samples,
             self.stencil_buffer,
+            self.hdr,
         )?;
 
         Ok(Canvas {

--- a/src/graphics/color.rs
+++ b/src/graphics/color.rs
@@ -144,7 +144,7 @@ impl Color {
     /// Returns the color with the RGB components multiplied by the alpha component.
     ///
     /// This can be useful when working with
-    /// [premultiplied alpha blending](super::BlendAlphaMode::Premultiplied), if
+    /// [premultiplied alpha blending](super::BlendState::alpha), if
     /// you want to convert a non-premultiplied color into its premultiplied
     /// version.
     pub fn to_premultiplied(self) -> Color {

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -151,7 +151,7 @@ impl Texture {
         data: &[u8],
         filter_mode: FilterMode,
     ) -> Result<Texture> {
-        let handle = device.new_texture(width, height, filter_mode)?;
+        let handle = device.new_texture(width, height, filter_mode, false)?;
 
         device.set_texture_data(&handle, data, 0, 0, width, height)?;
 

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -642,7 +642,7 @@ impl ImageData {
     /// Multiplies the RGB components of each pixel by the alpha component.
     ///
     /// This can be useful when working with
-    /// [premultiplied alpha blending](super::BlendAlphaMode::Premultiplied).
+    /// [premultiplied alpha blending](super::BlendState::alpha).
     pub fn premultiply(&mut self) {
         self.transform(|_, color| color.to_premultiplied())
     }

--- a/src/platform/device_gl.rs
+++ b/src/platform/device_gl.rs
@@ -605,6 +605,7 @@ impl GraphicsDevice {
         width: i32,
         height: i32,
         filter_mode: FilterMode,
+        hdr: bool,
     ) -> Result<RawTexture> {
         // TODO: I don't think we need mipmaps?
         unsafe {
@@ -658,10 +659,12 @@ impl GraphicsDevice {
 
             self.clear_errors();
 
+            let internal_format = if hdr { glow::RGBA16F } else { glow::RGBA };
+
             self.state.gl.tex_image_2d(
                 glow::TEXTURE_2D,
                 0,
-                glow::RGBA as i32, // love 2 deal with legacy apis
+                internal_format as i32, // love 2 deal with legacy apis
                 width,
                 height,
                 0,
@@ -768,6 +771,7 @@ impl GraphicsDevice {
         filter_mode: FilterMode,
         samples: u8,
         with_stencil_buffer: bool,
+        hdr: bool,
     ) -> Result<RawCanvasWithAttachments> {
         unsafe {
             let previous_read = self.state.current_read_framebuffer.get();
@@ -786,7 +790,7 @@ impl GraphicsDevice {
 
             self.bind_framebuffer(Some(canvas.id));
 
-            let color = self.new_texture(width, height, filter_mode)?;
+            let color = self.new_texture(width, height, filter_mode, hdr)?;
 
             self.state.gl.framebuffer_texture_2d(
                 glow::FRAMEBUFFER,


### PR DESCRIPTION
Added the possibility of creating Canvas that use RGBA16F as internal format, in order to have effects like HDR and Bloom.



```rust

let canvas = Canvas::builder(width, height).hdr(true).build(ctx)?;
```
