### PR TITLE
set_key_down() not sets the key pressed in key repeat is enabled

### DIFF
--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -223,7 +223,7 @@ pub fn get_keys_released(ctx: &Context) -> impl Iterator<Item = &Key> {
 pub(crate) fn set_key_down(ctx: &mut Context, key: Key) -> bool {
     let was_up = ctx.input.keys_down.insert(key);
 
-    if was_up {
+    if was_up || ctx.window.is_key_repeat_enabled() {
         ctx.input.keys_pressed.insert(key);
     }
 


### PR DESCRIPTION
It seems like a bug, if key_repeat is enabled and you hold a key you can get event `Event::KeyPressed` every SDL "repeat tick" but if you using `input::get_keys_pressed()` this key will show up only one time. I fixed it by adding check is_key_repeat_enabled() to `input::set_key_down()`