### PR TITLE
Add iterators to enumerate all keys and key labels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ sdl2_bundled = ["sdl2/bundled"]
 sdl2_static_link = ["sdl2/static-link"]
 
 # Disables automatic drawing for each frame.
-# Even if this feature is enabled, the drawing command will still be processed.
+# Even if this feature is enabled, drawing commands will still be processed.
 # but you will need to call `tetra::graphics::present` to get the actual drawing on the screen.
 # You can reduce the load of the Window Manager on your operating system by manually controlling when drawing needs to be done.
 disable_auto_redraw = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,7 @@ sdl2_bundled = ["sdl2/bundled"]
 
 # Links SDL2 statically (see https://hg.libsdl.org/SDL/file/default/docs/README-dynapi.md).
 sdl2_static_link = ["sdl2/static-link"]
+
+# Disables automatic drawing for each frame.
+# If you enable this feature, you will need to call `tetra::graphics::present` manually.
+disable_auto_redraw = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,7 @@ sdl2_bundled = ["sdl2/bundled"]
 sdl2_static_link = ["sdl2/static-link"]
 
 # Disables automatic drawing for each frame.
-# When this feature is enabled, draw commands will be processed, but you will need to call `tetra::graphics::present` to get the actual drawing on the screen.
+# Even if this feature is enabled, the drawing command will still be processed.
+# but you will need to call `tetra::graphics::present` to get the actual drawing on the screen.
+# You can reduce the load of the Window Manager on your operating system by manually controlling when drawing needs to be done.
 disable_auto_redraw = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ xi-unicode = "0.3.0"
 bytemuck = "1.5.0"
 num-traits = "0.2.14"
 lyon_tessellation = "0.17.4"
+strum = "0.22"
+strum_macros = "0.22"
+
 
 [dev-dependencies]
 rand = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,5 @@ sdl2_bundled = ["sdl2/bundled"]
 sdl2_static_link = ["sdl2/static-link"]
 
 # Disables automatic drawing for each frame.
-# If you enable this feature, you will need to call `tetra::graphics::present` manually.
+# When this feature is enabled, draw commands will be processed, but you will need to call `tetra::graphics::present` to get the actual drawing on the screen.
 disable_auto_redraw = []

--- a/src/context.rs
+++ b/src/context.rs
@@ -170,6 +170,7 @@ impl Context {
 
             state.draw(self)?;
 
+            #[cfg(not(feature = "disable_auto_redraw"))]
             graphics::present(self);
 
             // This provides a sensible FPS limit when running without vsync, and

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -258,7 +258,7 @@ impl Key {
 ///
 /// Serialization and deserialization of this type (via [Serde](https://serde.rs/))
 /// can be enabled via the `serde_support` feature.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EnumIter)]
 #[cfg_attr(
     feature = "serde_support",
     derive(serde::Serialize, serde::Deserialize)
@@ -401,6 +401,13 @@ pub enum KeyLabel {
     Space,
     Tab,
     Underscore,
+}
+
+impl KeyLabel {
+    /// Returns an iterator that enumerates all key labels.
+    pub fn all() -> KeyLabelIter {
+        Self::iter()
+    }
 }
 
 impl Display for KeyLabel {

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -1,4 +1,6 @@
 use std::fmt::{self, Display, Formatter};
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 
 use crate::Context;
 
@@ -21,7 +23,7 @@ use crate::Context;
 ///
 /// Serialization and deserialization of this type (via [Serde](https://serde.rs/))
 /// can be enabled via the `serde_support` feature.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EnumIter)]
 #[cfg_attr(
     feature = "serde_support",
     derive(serde::Serialize, serde::Deserialize)
@@ -232,6 +234,13 @@ pub enum Key {
         note = "`Key` now represents the physical position of a key, independent of the current keyboard layout, so this variant is no longer valid. To represent the key that is labelled with this character, use `KeyLabel`."
     )]
     Underscore,
+}
+
+impl Key {
+    /// Returns an iterator that enumerates all keys.
+    pub fn all() -> KeyIter {
+        Self::iter()
+    }
 }
 
 /// A key, as represented by the current system keyboard layout.


### PR DESCRIPTION
I am remapping the CapsLock key to the Control key.
If I are remapping on OS, before #277, you could detect all control key presses by using `tetra::input::is_key_modifier_down(ctx, KeyModifier::Ctrl)`

#277 Onwards, I can use `tetra::input::get_key_with_label` to check the physical key after remapping, but this method can only return a single key due to SDL2 specification.

Therefore, there is no way to detect when multiple physical keys are mapped to a single logical key.

This PR adds an iterator to Tetra that enumerates all items, and the following code solves this problem.

```rust
let is_ctrl_key_down = tetra::input::Key::all()
  .filter_map(|key| {
    tetra::input::get_key_label(ctx, key)
      .filter(|label| *label == tetra::input::KeyLabel::LeftCtrl)
      .map(|_| key)
  })
  .any(|key| tetra::input::is_key_down(ctx, key));
```