### PR TITLE
Add iterators to enumerate all keys and key labels 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ xi-unicode = "0.3.0"
 bytemuck = "1.5.0"
 num-traits = "0.2.14"
 lyon_tessellation = "0.17.4"
+strum = "0.22"
+strum_macros = "0.22"
+
 
 [dev-dependencies]
 rand = "0.8.0"

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -258,7 +258,7 @@ impl Key {
 ///
 /// Serialization and deserialization of this type (via [Serde](https://serde.rs/))
 /// can be enabled via the `serde_support` feature.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EnumIter)]
 #[cfg_attr(
     feature = "serde_support",
     derive(serde::Serialize, serde::Deserialize)
@@ -401,6 +401,13 @@ pub enum KeyLabel {
     Space,
     Tab,
     Underscore,
+}
+
+impl KeyLabel {
+    /// Returns an iterator that enumerates all key labels.
+    pub fn all() -> KeyLabelIter {
+        Self::iter()
+    }
 }
 
 impl Display for KeyLabel {

--- a/src/input/keyboard.rs
+++ b/src/input/keyboard.rs
@@ -1,4 +1,6 @@
 use std::fmt::{self, Display, Formatter};
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 
 use crate::Context;
 
@@ -21,7 +23,7 @@ use crate::Context;
 ///
 /// Serialization and deserialization of this type (via [Serde](https://serde.rs/))
 /// can be enabled via the `serde_support` feature.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EnumIter)]
 #[cfg_attr(
     feature = "serde_support",
     derive(serde::Serialize, serde::Deserialize)
@@ -232,6 +234,13 @@ pub enum Key {
         note = "`Key` now represents the physical position of a key, independent of the current keyboard layout, so this variant is no longer valid. To represent the key that is labelled with this character, use `KeyLabel`."
     )]
     Underscore,
+}
+
+impl Key {
+    /// Returns an iterator that enumerates all keys.
+    pub fn all() -> KeyIter {
+        Self::iter()
+    }
 }
 
 /// A key, as represented by the current system keyboard layout.


### PR DESCRIPTION
I am remapping the CapsLock key to the Control key.
If I are remapping by OS, before #277, I could detect all logical control key presses by using `tetra::input::is_key_modifier_down(ctx, KeyModifier::Ctrl)`

#277 Afterwards, I can use `tetra::input::get_key_with_label` to check the physical key after remapping, but this method can only return a single key due to SDL2 specification.

Therefore, there is no way to detect when multiple physical keys are mapped to a single logical key.

This PR adds iterators to Tetra that enumerates all items, and the following code solves this problem.

```rust
use tetra::input;
let is_ctrl_key_down = input::Key::all()
  .filter_map(|key| {
    input::get_key_label(ctx, key)
      .filter(|label| {
        *label == input::KeyLabel::LeftCtrl || *label == input::KeyLabel::RightCtrl
      })
      .map(|_| key)
  })
  .any(|key| input::is_key_down(ctx, key));
```
