### PR TITLE
Change KeyModifier to be layout-based again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ From 0.4.0 onwards, all breaking changes will be explicitly labelled, to make it
 
 This project adheres to Semantic Versioning.
 
+## [Upcoming]
+
+### Changed
+
+* `KeyModifier`'s behaviour has been reverted to be layout-based rather than position-based.
+    * This better matches the expected behaviour for keyboard shortcuts (which is the primary use case for this type), and the behaviour of the underlying platform code.
+
 ## [0.6.7] - 2021-11-05
 
 ### Changed

--- a/src/input.rs
+++ b/src/input.rs
@@ -41,6 +41,8 @@ pub(crate) struct InputContext {
     keys_pressed: HashSet<Key>,
     keys_released: HashSet<Key>,
 
+    key_modifier_state: KeyModifierState,
+
     mouse_buttons_down: HashSet<MouseButton>,
     mouse_buttons_pressed: HashSet<MouseButton>,
     mouse_buttons_released: HashSet<MouseButton>,
@@ -58,6 +60,8 @@ impl InputContext {
             keys_down: HashSet::new(),
             keys_pressed: HashSet::new(),
             keys_released: HashSet::new(),
+
+            key_modifier_state: KeyModifierState::default(),
 
             mouse_buttons_down: HashSet::new(),
             mouse_buttons_pressed: HashSet::new(),


### PR DESCRIPTION
As reported on #293, the keyboard API changes introduced in 0.6.6 made it very difficult to implement 'native' feeling keyboard shortcuts. Since this is basically the entire reason for `KeyModifier` to exist, I think it's worth changing the behaviour for that type back to how it was.

cc: @sumibi-yakitori - can you try this branch and let me know if it behaves as expected?