### PR TITLE
Custom blend modes

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -550,19 +550,19 @@ pub enum BlendMode {
     /// Custom blend mode
     Custom{
         /// The blending equation to use to compute the value.
-        equation: BlendModeEquation,
+        equation: BlendEquation,
 
         /// The multiplier applied to the color from the shader.
-        src_rgb: BlendModeCustomParam,
+        src_rgb: BlendFactor,
 
         /// The multiplier applied to the alpha value from the shader
-        src_alpha: BlendModeCustomParam,
+        src_alpha: BlendFactor,
 
         /// The multiplier applied to the color already present on the destination
-        dst_rgb: BlendModeCustomParam,
+        dst_rgb: BlendFactor,
 
         /// The multiplier applied to the alpha value already present on the destination
-        dst_alpha: BlendModeCustomParam,
+        dst_alpha: BlendFactor,
     },
 
     /// The pixel colors of the drawn content will be subtracted from the pixel colors
@@ -580,9 +580,9 @@ impl Default for BlendMode {
     }
 }
 
-/// BlendMode equation to use in `BlendMode::Custom`.
+/// Blend equation to use in `BlendMode::Custom`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BlendModeEquation{
+pub enum BlendEquation {
     /// The source and destination colors are added to each other.
    Add,
 
@@ -593,10 +593,10 @@ pub enum BlendModeEquation{
    ReverseSubtract
 }
 
-/// BlendMode param to use in `BlendMode::Custom`
+/// Blend factor to use in `BlendMode::Custom`
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(missing_docs)]
-pub enum BlendModeCustomParam{
+pub enum BlendFactor {
     One, Zero,
     SrcAlpha, SrcColor,
     DstAlpha, DstColor,
@@ -605,19 +605,19 @@ pub enum BlendModeCustomParam{
 }
 
 #[doc(hidden)]
-impl BlendModeCustomParam{
+impl BlendFactor {
     pub (crate) fn as_glow(self)-> u32{
        match self{
-           BlendModeCustomParam::One => glow::ONE,
-           BlendModeCustomParam::Zero => glow::ZERO,
-           BlendModeCustomParam::SrcAlpha => glow::SRC_ALPHA,
-           BlendModeCustomParam::SrcColor => glow::SRC_COLOR,
-           BlendModeCustomParam::DstAlpha => glow::DST_ALPHA,
-           BlendModeCustomParam::DstColor => glow::DST_COLOR,
-           BlendModeCustomParam::OneMinusSrcAlpha => glow::ONE_MINUS_SRC_ALPHA,
-           BlendModeCustomParam::OneMinusDstAlpha => glow::ONE_MINUS_DST_ALPHA,
-           BlendModeCustomParam::OneMinusSrcColor => glow::ONE_MINUS_SRC_COLOR,
-           BlendModeCustomParam::OneMinusDstColor => glow::ONE_MINUS_DST_COLOR,
+           BlendFactor::One => glow::ONE,
+           BlendFactor::Zero => glow::ZERO,
+           BlendFactor::SrcAlpha => glow::SRC_ALPHA,
+           BlendFactor::SrcColor => glow::SRC_COLOR,
+           BlendFactor::DstAlpha => glow::DST_ALPHA,
+           BlendFactor::DstColor => glow::DST_COLOR,
+           BlendFactor::OneMinusSrcAlpha => glow::ONE_MINUS_SRC_ALPHA,
+           BlendFactor::OneMinusDstAlpha => glow::ONE_MINUS_DST_ALPHA,
+           BlendFactor::OneMinusSrcColor => glow::ONE_MINUS_SRC_COLOR,
+           BlendFactor::OneMinusDstColor => glow::ONE_MINUS_DST_COLOR,
        }
     }
 }

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -547,6 +547,24 @@ pub enum BlendMode {
     /// already in the target. The target's alpha will not be affected.
     Add(BlendAlphaMode),
 
+    /// Custom blend mode
+    Custom{
+        /// The blending equation to use to compute the value.
+        equation: BlendModeEquation,
+
+        /// The multiplier applied to the color from the shader.
+        src_rgb: BlendModeCustomParam,
+
+        /// The multiplier applied to the alpha value from the shader
+        src_alpha: BlendModeCustomParam,
+
+        /// The multiplier applied to the color already present on the destination
+        dst_rgb: BlendModeCustomParam,
+
+        /// The multiplier applied to the alpha value already present on the destination
+        dst_alpha: BlendModeCustomParam,
+    },
+
     /// The pixel colors of the drawn content will be subtracted from the pixel colors
     /// already in the target. The target's alpha will not be affected.
     Subtract(BlendAlphaMode),
@@ -559,6 +577,48 @@ pub enum BlendMode {
 impl Default for BlendMode {
     fn default() -> BlendMode {
         BlendMode::Alpha(BlendAlphaMode::Multiply)
+    }
+}
+
+/// BlendMode equation to use in `BlendMode::Custom`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendModeEquation{
+    /// The source and destination colors are added to each other.
+   Add,
+
+   /// Subtracts the destination from the source.
+   Subtract,
+
+   /// Subtracts the source from the destination.
+   ReverseSubtract
+}
+
+/// BlendMode param to use in `BlendMode::Custom`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum BlendModeCustomParam{
+    One, Zero,
+    SrcAlpha, SrcColor,
+    DstAlpha, DstColor,
+    OneMinusSrcAlpha, OneMinusDstAlpha,
+    OneMinusSrcColor, OneMinusDstColor
+}
+
+#[doc(hidden)]
+impl BlendModeCustomParam{
+    pub (crate) fn as_glow(self)-> u32{
+       match self{
+           BlendModeCustomParam::One => glow::ONE,
+           BlendModeCustomParam::Zero => glow::ZERO,
+           BlendModeCustomParam::SrcAlpha => glow::SRC_ALPHA,
+           BlendModeCustomParam::SrcColor => glow::SRC_COLOR,
+           BlendModeCustomParam::DstAlpha => glow::DST_ALPHA,
+           BlendModeCustomParam::DstColor => glow::DST_COLOR,
+           BlendModeCustomParam::OneMinusSrcAlpha => glow::ONE_MINUS_SRC_ALPHA,
+           BlendModeCustomParam::OneMinusDstAlpha => glow::ONE_MINUS_DST_ALPHA,
+           BlendModeCustomParam::OneMinusSrcColor => glow::ONE_MINUS_SRC_COLOR,
+           BlendModeCustomParam::OneMinusDstColor => glow::ONE_MINUS_DST_COLOR,
+       }
     }
 }
 

--- a/src/platform/device_gl.rs
+++ b/src/platform/device_gl.rs
@@ -6,9 +6,12 @@ use std::slice;
 use glow::{Context as GlowContext, HasContext, PixelPackData, PixelUnpackData};
 
 use crate::error::{Result, TetraError};
-use crate::graphics::{BlendModeEquation, mesh::{BufferUsage, Vertex, VertexWinding}, StencilState, StencilTest};
 use crate::graphics::{
-    BlendAlphaMode, BlendMode, Color, FilterMode, GraphicsDeviceInfo, StencilAction,
+    mesh::{BufferUsage, Vertex, VertexWinding},
+    StencilState, StencilTest
+};
+use crate::graphics::{
+    BlendModeEquation, BlendAlphaMode, BlendMode, Color, FilterMode, GraphicsDeviceInfo, StencilAction,
 };
 use crate::math::{Mat2, Mat3, Mat4, Vec2, Vec3, Vec4};
 

--- a/src/platform/device_gl.rs
+++ b/src/platform/device_gl.rs
@@ -11,7 +11,7 @@ use crate::graphics::{
     StencilState, StencilTest
 };
 use crate::graphics::{
-    BlendModeEquation, BlendAlphaMode, BlendMode, Color, FilterMode, GraphicsDeviceInfo, StencilAction,
+    BlendEquation, BlendAlphaMode, BlendMode, Color, FilterMode, GraphicsDeviceInfo, StencilAction,
 };
 use crate::math::{Mat2, Mat3, Mat4, Vec2, Vec3, Vec4};
 
@@ -1213,9 +1213,9 @@ impl BlendMode {
             BlendMode::Multiply => glow::FUNC_ADD,
             BlendMode::Custom { equation,.. } => {
                 match equation{
-                    BlendModeEquation::Add => glow::FUNC_ADD,
-                    BlendModeEquation::Subtract => glow::FUNC_SUBTRACT,
-                    BlendModeEquation::ReverseSubtract => glow::FUNC_REVERSE_SUBTRACT
+                    BlendEquation::Add => glow::FUNC_ADD,
+                    BlendEquation::Subtract => glow::FUNC_SUBTRACT,
+                    BlendEquation::ReverseSubtract => glow::FUNC_REVERSE_SUBTRACT
                 }
             }
         }

--- a/src/platform/device_gl.rs
+++ b/src/platform/device_gl.rs
@@ -6,10 +6,7 @@ use std::slice;
 use glow::{Context as GlowContext, HasContext, PixelPackData, PixelUnpackData};
 
 use crate::error::{Result, TetraError};
-use crate::graphics::{
-    mesh::{BufferUsage, Vertex, VertexWinding},
-    StencilState, StencilTest,
-};
+use crate::graphics::{BlendModeEquation, mesh::{BufferUsage, Vertex, VertexWinding}, StencilState, StencilTest};
 use crate::graphics::{
     BlendAlphaMode, BlendMode, Color, FilterMode, GraphicsDeviceInfo, StencilAction,
 };
@@ -1211,6 +1208,13 @@ impl BlendMode {
             BlendMode::Add(_) => glow::FUNC_ADD,
             BlendMode::Subtract(_) => glow::FUNC_REVERSE_SUBTRACT,
             BlendMode::Multiply => glow::FUNC_ADD,
+            BlendMode::Custom { equation,.. } => {
+                match equation{
+                    BlendModeEquation::Add => glow::FUNC_ADD,
+                    BlendModeEquation::Subtract => glow::FUNC_SUBTRACT,
+                    BlendModeEquation::ReverseSubtract => glow::FUNC_REVERSE_SUBTRACT
+                }
+            }
         }
     }
 
@@ -1229,6 +1233,7 @@ impl BlendMode {
                 BlendAlphaMode::Premultiplied => glow::ONE,
             },
             BlendMode::Multiply => glow::DST_COLOR,
+            BlendMode::Custom {src_rgb,..} => src_rgb.as_glow(),
         }
     }
 
@@ -1238,6 +1243,7 @@ impl BlendMode {
             BlendMode::Add(_) => glow::ZERO,
             BlendMode::Subtract(_) => glow::ZERO,
             BlendMode::Multiply => glow::DST_COLOR,
+            BlendMode::Custom {src_alpha,..} => src_alpha.as_glow(),
         }
     }
 
@@ -1247,6 +1253,8 @@ impl BlendMode {
             BlendMode::Add(_) => glow::ONE,
             BlendMode::Subtract(_) => glow::ONE,
             BlendMode::Multiply => glow::ZERO,
+            BlendMode::Custom {dst_rgb,..} => dst_rgb.as_glow(),
+
         }
     }
 
@@ -1256,6 +1264,7 @@ impl BlendMode {
             BlendMode::Add(_) => glow::ONE,
             BlendMode::Subtract(_) => glow::ONE,
             BlendMode::Multiply => glow::ZERO,
+            BlendMode::Custom {dst_alpha,..} => dst_alpha.as_glow(),
         }
     }
 }


### PR DESCRIPTION
I am using a texture to store lighting information ([like in this article](https://medium.com/@NoelFB/remaking-celestes-lighting-3478d6f10bf)) in each RGBA channel and in order to write/erase light I need two custom blendmodes.

```rust
            store_blend_mode: BlendMode::Custom {
                equation: BlendEquation::Add,
                src_rgb: BlendFactor::One,
                src_alpha: BlendFactor::One,
                dst_rgb: BlendFactor::One,
                dst_alpha: BlendFactor::One
            },

            erase_blend_mode: BlendMode::Custom {
                equation: BlendEquation::ReverseSubtract,
                src_rgb: BlendFactor::One,
                src_alpha: BlendFactor::One,
                dst_rgb: BlendFactor::One,
                dst_alpha: BlendFactor::One
            }
```
