### PR TITLE
Add `Animation::is_finished`

### DIFF
--- a/src/graphics/animation.rs
+++ b/src/graphics/animation.rs
@@ -1,5 +1,6 @@
 //! Functions and types relating to animations.
 
+use std::ops::Not;
 use std::time::Duration;
 
 use crate::graphics::texture::Texture;
@@ -198,5 +199,15 @@ impl Animation {
     /// skip frames.
     pub fn set_current_frame_time(&mut self, duration: Duration) {
         self.timer = duration;
+    }
+
+    /// Returns true if this animation will no longer advance.
+    pub fn is_finished(&self) -> bool {
+        self.repeating.not() && self.frames_remaining() == 0
+    }
+
+    /// How many frames are remaining in the current cycle.
+    fn frames_remaining(&self) -> usize {
+        self.current_frame < self.frames.len() - 1
     }
 }


### PR DESCRIPTION
Hey there :wave:  Congrats on this project :smiley:   

This PR proposes `Animation::is_finished`.

## Motivation

This allows us to quickly get rid of "one-off" animations, such as an explosion, damage indicator or whatnot

```rust
let is_not_finished = |anim| anim.is_finished().not();

animations.retain(is_not_finished);
```