### PR TITLE
Fix typo on CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at 27cupsofcoffee@gmail.com. All
+reported by contacting the project team at 17cupsofcoffee@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Fixes enforcement email addresse. I could be wrong though, so apologies if that is the case.

Edit: Nevermind, just saw that the email addresse is used throughout the project. So this PR is either redundant, or the email addresse has been mistyped throughout the project, which seems very unlikely.