### PR TITLE
Add some utility methods to ScreenScaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ This project adheres to Semantic Versioning.
 ### Added
 
 * `Animation` now has `is_finished` and `has_frames_remaining` utility methods. ([@vrmiguel](https://github.com/vrmiguel) in [#315](https://github.com/17cupsofcoffee/tetra/pull/315))
-* `ContextBuilder` now has a `fps_limit` option, which allows users to disable the built-in FPS capping behaviour. ([@fililip](https://github.com/fililip) in [#321](https://github.com/17cupsofcoffee/tetra/pull/321))
+* `ContextBuilder` now has a `fps_limit` option, which allows users to disable the built-in FPS capping
+  behaviour. ([@fililip](https://github.com/fililip) in [#321](https://github.com/17cupsofcoffee/tetra/pull/321))
+* `ScreenScaler` now has `scale_factor` and sizing utility methods. ([@timerertim](https://github.com/timerertim)
+  in [#327](https://github.com/17cupsofcoffee/tetra/pull/327))
 
 ## [0.7.0] - 2022-03-23
 

--- a/src/graphics/scaling.rs
+++ b/src/graphics/scaling.rs
@@ -1,11 +1,11 @@
 //! Functions and types relating to screen scaling.
 
+use crate::Context;
 use crate::error::Result;
 use crate::graphics::{self, Canvas, DrawParams, Rectangle};
 use crate::input;
 use crate::math::Vec2;
 use crate::window;
-use crate::Context;
 
 /// A wrapper for a [`Canvas`] that handles scaling the image to fit the screen.
 ///
@@ -19,6 +19,8 @@ pub struct ScreenScaler {
     canvas: Canvas,
     mode: ScalingMode,
     screen_rect: Rectangle,
+    inner_width: i32,
+    inner_height: i32,
     outer_width: i32,
     outer_height: i32,
 }
@@ -42,6 +44,8 @@ impl ScreenScaler {
             canvas,
             mode,
             screen_rect,
+            inner_width,
+            inner_height,
             outer_width,
             outer_height,
         })
@@ -100,6 +104,29 @@ impl ScreenScaler {
                 outer_height,
             );
         }
+    }
+
+    /// Returns the scaler's outer size  (i.e. the size of the box that the screen will be scaled to
+    /// fit within).  
+    /// The format is (width, height).
+    pub fn outer_size(&self) -> (i32, i32) {
+        (self.outer_width, self.outer_height)
+    }
+
+    /// Returns the scaler's inner size (i.e. the logical screen size).  
+    /// The format is (width, height).
+    pub fn inner_size(&self) -> (i32, i32) {
+        (self.inner_width, self.inner_height)
+    }
+
+    /// Returns the optimal scale factor for the current `ScalingMode` and configured sizes.  
+    /// This can be used for simple use cases where scaling by [canvas](Self::canvas) is not
+    /// feasible (e.g. 3rd party UI libraries).
+    pub fn scale_factor(&self) -> f32 {
+        f32::min(
+            self.screen_rect.width as f32 / self.inner_width as f32,
+            self.screen_rect.height as f32 / self.inner_height as f32,
+        )
     }
 
     /// Returns a reference to the canvas that is being scaled.


### PR DESCRIPTION
This PR would add some useful utility methods to the `ScreenScaler` struct.

First of all the current sizes (inner and outer)  can easily be retrieved.
Furthermore a scaling factor can be calculated. The scaling factor is a single floating point number, representing how much unscaled objects need to be scaled up (or down respectively) in order to fit the screen using the `ScalingMode` of the screen scaler.

### Motivation

This would allow easy integration of 3rd party libraries using the OpenGL context (e.g. UI libraries).

```rust
fn update(&mut self, ctx: &mut Context) -> Result<(), Error> {
    self.ui_scale = self.scaler.scale_factor();
}

fn draw(&mut self, ctx: &mut Context) -> Result<(), Error> {
    ui_library::draw(ctx, &self.ui, self.ui_scale); // Just some pseudo usage example of a 3rd party library
}
```