### PR TITLE
Add the ability to get the display's refresh rate

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,10 @@ pub enum TetraError {
     /// but was unable to do so.
     FailedToChangeDisplayMode(String),
 
+    /// Returned when your game tried to get the display's refresh rate
+    /// but was unable to do so.
+    FailedToGetRefreshRate(String),
+
     /// Returned when a shape cannot be tessellated.
     TessellationError(TessellationError),
 }
@@ -95,6 +99,9 @@ impl Display for TetraError {
                 "Not enough data was provided to fill a buffer - expected {}, found {}.",
                 expected, actual
             ),
+            TetraError::FailedToGetRefreshRate(msg) => {
+                write!(f, "Failed to get refresh rate: {}", msg)
+            }
             TetraError::FailedToChangeDisplayMode(msg) => {
                 write!(f, "Failed to change display mode: {}", msg)
             }
@@ -119,6 +126,7 @@ impl Error for TetraError {
             TetraError::InvalidSound(reason) => Some(reason),
             TetraError::NotEnoughData { .. } => None,
             TetraError::NoAudioDevice => None,
+            TetraError::FailedToGetRefreshRate(_) => None,
             TetraError::FailedToChangeDisplayMode(_) => None,
             TetraError::TessellationError(reason) => Some(reason),
         }

--- a/src/platform/window_sdl.rs
+++ b/src/platform/window_sdl.rs
@@ -199,6 +199,13 @@ impl Window {
         self.sdl_window.raise()
     }
 
+    pub fn get_refresh_rate(&self) -> Result<i32> {
+        self.sdl_window
+            .display_mode()
+            .map(|display_mode| display_mode.refresh_rate)
+            .map_err(|e| TetraError::FailedToGetRefreshRate(e.to_string()))
+    }
+
     pub fn get_window_title(&self) -> &str {
         self.sdl_window.title()
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -34,6 +34,11 @@ pub fn focus(ctx: &mut Context) {
     ctx.window.focus();
 }
 
+/// Gets the display's refresh rate.
+pub fn get_refresh_rate(ctx: &Context) -> Result<i32> {
+    ctx.window.get_refresh_rate()
+}
+
 /// Gets the current title of the window.
 pub fn get_title(ctx: &Context) -> &str {
     ctx.window.get_window_title()


### PR DESCRIPTION
This might come in handy for frame timing calculations. Tested on Wayland and X11, works fine.