### PR TITLE
Add `window::set_text_input_enabled()` and `window::is_text_input_enabled()`

### DIFF
--- a/src/platform/window_sdl.rs
+++ b/src/platform/window_sdl.rs
@@ -485,6 +485,19 @@ impl Window {
         let sdl_keycode = Keycode::from_scancode(sdl_scancode, SDL_KMOD_NONE, false)?;
         from_sdl_keycode(sdl_keycode)
     }
+
+    pub fn set_text_input_enabled(&mut self, text_input_enabled: bool) {
+        let text_input = self.video_sys.text_input();
+        if text_input_enabled {
+            text_input.start(&self.sdl_window);
+        } else {
+            text_input.stop(&self.sdl_window);
+        }
+    }
+
+    pub fn is_text_input_enabled(&self) -> bool {
+        self.video_sys.text_input().is_active(&self.sdl_window)
+    }
 }
 
 pub fn handle_events<S, E>(ctx: &mut Context, state: &mut S) -> result::Result<(), E>

--- a/src/window.rs
+++ b/src/window.rs
@@ -446,6 +446,21 @@ pub fn is_key_repeat_enabled(ctx: &Context) -> bool {
     ctx.window.is_key_repeat_enabled()
 }
 
+/// Sets whether or not text input is enabled.
+///
+/// When enabled, typing fires [`TextInput`](crate::Event::TextInput) events carrying the
+/// composed text (and, on platforms with an IME, activates it). When disabled, keystrokes
+/// still fire [`KeyPressed`](crate::Event::KeyPressed)/[`KeyReleased`](crate::Event::KeyReleased)
+/// but produce no `TextInput`.
+pub fn set_text_input_enabled(ctx: &mut Context, text_input_enabled: bool) {
+    ctx.window.set_text_input_enabled(text_input_enabled);
+}
+
+/// Returns whether or not text input is currently enabled.
+pub fn is_text_input_enabled(ctx: &Context) -> bool {
+    ctx.window.is_text_input_enabled()
+}
+
 /// Represents the position of a window on the screen.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
TextInput messages were enabled by default in #355. Recently I added some text fields to my game and found that it would be much more convenient to have ability to enable it only at specific scenes (or only when some gui text field is focused) and disable at others. So I added these two simple public API methods. Maybe it will be useful for someone else too.